### PR TITLE
Fix: docker container name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ published-app/
 .codex/
 
 apps/sandbox/data
+apps/sandbox/storage/attachments

--- a/apps/sandbox/docker-compose.fullapp.dev.yml
+++ b/apps/sandbox/docker-compose.fullapp.dev.yml
@@ -60,7 +60,7 @@ services:
 
   postgres:
     image: pgvector/pgvector:pg17-trixie
-    container_name: mercato-postgres-${DEPLOY_ENV:-local}
+    container_name: mercato-postgres-module-${DEPLOY_ENV:-local}
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
@@ -78,7 +78,7 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: mercato-redis-${DEPLOY_ENV:-local}
+    container_name: mercato-redis-module-${DEPLOY_ENV:-local}
     volumes:
       - redis_data:/data
     healthcheck:
@@ -91,7 +91,7 @@ services:
 
   meilisearch:
     image: getmeili/meilisearch:v1.11
-    container_name: mercato-meilisearch-${DEPLOY_ENV:-local}
+    container_name: mercato-meilisearch-module-${DEPLOY_ENV:-local}
     restart: unless-stopped
     environment:
       MEILI_ENV: development
@@ -109,11 +109,11 @@ services:
 
 volumes:
   postgres_data:
-    name: mercato-postgres-data-${DEPLOY_ENV:-local}
+    name: mercato-postgres-module-data-${DEPLOY_ENV:-local}
   redis_data:
-    name: mercato-redis-data-${DEPLOY_ENV:-local}
+    name: mercato-redis-module-data-${DEPLOY_ENV:-local}
   meilisearch_data:
-    name: mercato-meilisearch-data-${DEPLOY_ENV:-local}
+    name: mercato-meilisearch-module-data-${DEPLOY_ENV:-local}
   init_marker:
     name: mercato-init-marker-${DEPLOY_ENV:-local}
   attachments_storage:

--- a/apps/sandbox/docker-compose.fullapp.yml
+++ b/apps/sandbox/docker-compose.fullapp.yml
@@ -60,7 +60,7 @@ services:
 
   postgres:
     image: pgvector/pgvector:pg17-trixie
-    container_name: mercato-postgres-${DEPLOY_ENV:-local}
+    container_name: mercato-postgres-module-${DEPLOY_ENV:-local}
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
@@ -78,7 +78,7 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: mercato-redis-${DEPLOY_ENV:-local}
+    container_name: mercato-redis-module-${DEPLOY_ENV:-local}
     volumes:
       - redis_data:/data
     healthcheck:
@@ -91,7 +91,7 @@ services:
 
   meilisearch:
     image: getmeili/meilisearch:v1.11
-    container_name: mercato-meilisearch-${DEPLOY_ENV:-local}
+    container_name: mercato-meilisearch-module-${DEPLOY_ENV:-local}
     restart: unless-stopped
     environment:
       MEILI_ENV: development
@@ -109,11 +109,11 @@ services:
 
 volumes:
   postgres_data:
-    name: mercato-postgres-data-${DEPLOY_ENV:-local}
+    name: mercato-postgres-module-data-${DEPLOY_ENV:-local}
   redis_data:
-    name: mercato-redis-data-${DEPLOY_ENV:-local}
+    name: mercato-redis-module-data-${DEPLOY_ENV:-local}
   meilisearch_data:
-    name: mercato-meilisearch-data-${DEPLOY_ENV:-local}
+    name: mercato-meilisearch-module-data-${DEPLOY_ENV:-local}
   init_marker:
     name: mercato-init-marker-${DEPLOY_ENV:-local}
   attachments_storage:

--- a/apps/sandbox/docker-compose.yml
+++ b/apps/sandbox/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   postgres:
     image: pgvector/pgvector:pg17-trixie
-    container_name: mercato-postgres
+    container_name: mercato-postgres-module
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
@@ -21,7 +21,7 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: mercato-redis
+    container_name: mercato-redis-module
     ports:
       - "${REDIS_PORT:-6379}:6379"
     volumes:
@@ -36,7 +36,7 @@ services:
 
   meilisearch:
     image: getmeili/meilisearch:v1.11
-    container_name: mercato-meilisearch
+    container_name: mercato-meilisearch-module
     restart: unless-stopped
     environment:
       MEILI_ENV: development
@@ -56,11 +56,11 @@ services:
 
 volumes:
   postgres_data:
-    name: mercato-postgres-data
+    name: mercato-postgres-module-data
   redis_data:
-    name: mercato-redis-data
+    name: mercato-redis-module-data
   meilisearch_data:
-    name: mercato-meilisearch-data
+    name: mercato-meilisearch-module-data
 
 networks:
   mercato-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   postgres:
     image: pgvector/pgvector:pg17-trixie
-    container_name: mercato-postgres
+    container_name: mercato-postgres-module
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
@@ -21,7 +21,7 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: mercato-redis
+    container_name: mercato-redis-module
     ports:
       - "${REDIS_PORT:-6379}:6379"
     volumes:
@@ -36,7 +36,7 @@ services:
 
   meilisearch:
     image: getmeili/meilisearch:v1.11
-    container_name: mercato-meilisearch
+    container_name: mercato-meilisearch-module
     restart: unless-stopped
     environment:
       MEILI_ENV: development
@@ -74,11 +74,11 @@ services:
 
 volumes:
   postgres_data:
-    name: mercato-postgres-data
+    name: mercato-postgres-module-data
   redis_data:
-    name: mercato-redis-data
+    name: mercato-redis-module-data
   meilisearch_data:
-    name: mercato-meilisearch-data
+    name: mercato-meilisearch-module-data
   verdaccio_storage:
   verdaccio_conf:
 


### PR DESCRIPTION
## Summary

- Rename all Docker container and volume names in every `docker-compose` file to include a `-module` suffix (e.g. `mercato-postgres` → `mercato-postgres-module`, `mercato-postgres-data` → `mercato-postgres-module-data`)
- Affected files: `docker-compose.yml`, `apps/sandbox/docker-compose.yml`, `apps/sandbox/docker-compose.fullapp.yml`, `apps/sandbox/docker-compose.fullapp.dev.yml`

## Why

When developers run this repo's Docker stack alongside the **main openmercato repository** on the same machine, Docker rejects the startup because both stacks use identical container and volume names. The `-module` suffix makes the namespacing explicit and allows both stacks to run simultaneously without conflicts.

## Migration note

If you had previously started containers from this repo, you will need to remove the old named volumes before starting fresh:

```bash
docker volume rm mercato-postgres-data mercato-redis-data mercato-meilisearch-data
