### PR TITLE
feat(github): partner /label command via shared workflow

### DIFF
--- a/.github/workflows/partner-label.yml
+++ b/.github/workflows/partner-label.yml
@@ -1,0 +1,22 @@
+name: Partner label command
+
+# Thin caller — the logic and the certified-partners registry live in
+# open-mercato/open-mercato:
+#   .github/workflows/partner-label.yml
+#   .github/certified-partners.yml
+#
+# Contributors listed in the registry can comment
+# /label partner-request or /unlabel partner-request on issues and PRs.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  partner-label:
+    if: startsWith(github.event.comment.body, '/label ') || startsWith(github.event.comment.body, '/unlabel ')
+    uses: open-mercato/open-mercato/.github/workflows/partner-label.yml@main


### PR DESCRIPTION
## What

Thin caller for the reusable partner-label workflow that lives in `open-mercato/open-mercato` (`.github/workflows/partner-label.yml`), together with the shared certified-partners registry (`.github/certified-partners.yml`).

Contributors listed in the registry can comment `/label partner-request` / `/unlabel partner-request` on any issue or PR here; a 👍 reaction confirms success. The `partner-request` label has been created in this repo (same color as in the main repo).

**Depends on** open-mercato/open-mercato#4727 — merge that one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)